### PR TITLE
Update library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -2,14 +2,12 @@
   "name": "DHTNEW",
   "keywords": "DHT11, DHT22, DHT33, DHT44, AM2301, AM2302, AM2303, autodetect, offset",
   "description": "Arduino library for DHT temperature and humidity sensor, with automatic sensortype recognition.",
-  "authors":
-  [
-    {
-      "name": "Rob Tillaart",
-      "email": "Rob.Tillaart@gmail.com",
-      "maintainer": true
-    }
-  ],
+  "authors": 
+  {
+    "name": "Rob Tillaart",
+    "email": "Rob.Tillaart@gmail.com",
+    "maintainer": true
+  },
   "repository":
   {
     "type": "git",


### PR DESCRIPTION
platformio lib register this file results in a cryptic error:
** Error: Could not parse manifest -> Expecting value: line 6 column 1 (char 5)*

changed the author array to a single field as the array only holds one field. Could be the cause although it is within specification