### PR TITLE
read() should return DHTLIB_WAITING_FOR_READ when waiting for read

### DIFF
--- a/dhtnew.cpp
+++ b/dhtnew.cpp
@@ -78,6 +78,7 @@ void DHTNEW::setType(uint8_t type)
 
 // return values:
 // DHTLIB_OK
+// DHTLIB_WAITING_FOR_READ
 // DHTLIB_ERROR_CHECKSUM
 // DHTLIB_ERROR_BIT_SHIFT
 // DHTLIB_ERROR_SENSOR_NOT_READY
@@ -96,7 +97,7 @@ int DHTNEW::read()
   {
     while (millis() - _lastRead < _readDelay)
     {
-      if (!_waitForRead) return DHTLIB_OK;
+      if (!_waitForRead) return DHTLIB_WAITING_FOR_READ;
       yield();
     }
     return _read();

--- a/dhtnew.h
+++ b/dhtnew.h
@@ -29,6 +29,7 @@
 #define DHTLIB_ERROR_TIMEOUT_C           -5
 #define DHTLIB_ERROR_TIMEOUT_D           -6
 #define DHTLIB_ERROR_TIMEOUT_B           -7
+#define DHTLIB_WAITING_FOR_READ          -8
 
 #ifndef DHTLIB_INVALID_VALUE
 #define DHTLIB_INVALID_VALUE           -999

--- a/examples/dhtnew_array/dhtnew_array.ino
+++ b/examples/dhtnew_array/dhtnew_array.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: dhtnew_array.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.3
+// VERSION: 0.1.4
 // PURPOSE: DHTNEW library test sketch for Arduino
 //     URL: https://github.com/RobTillaart/DHTNew
 
@@ -10,7 +10,8 @@
 // 0.1.1    2020-04-30 replaced humidity and temperature with functions
 // 0.1.2    2020-06-08 improved error handling
 // 0.1.3    2020-06-15 match 0.3.0 error handling
-//
+// 0.1.3    2020-11-09 wait for read handling
+// 
 // DHT PIN layout from left to right
 // =================================
 // FRONT : DESCRIPTION
@@ -85,6 +86,9 @@ void test(int idx)
       break;
     case DHTLIB_ERROR_BIT_SHIFT:
       Serial.print("Bit shift error,\t");
+      break;
+    case DHTLIB_WAITING_FOR_READ:
+      Serial.print("Waiting for read,\t");
       break;
     default:
       Serial.print("Unknown: ");

--- a/examples/dhtnew_array/dhtnew_array.ino
+++ b/examples/dhtnew_array/dhtnew_array.ino
@@ -10,7 +10,7 @@
 // 0.1.1    2020-04-30 replaced humidity and temperature with functions
 // 0.1.2    2020-06-08 improved error handling
 // 0.1.3    2020-06-15 match 0.3.0 error handling
-// 0.1.3    2020-11-09 wait for read handling
+// 0.1.4    2020-11-09 wait for read handling
 // 
 // DHT PIN layout from left to right
 // =================================

--- a/examples/dhtnew_endless/dhtnew_endless.ino
+++ b/examples/dhtnew_endless/dhtnew_endless.ino
@@ -9,10 +9,11 @@
 // 0.1.0    2020-06-04 initial version
 // 0.1.1    2020-06-15 match 0.3.0 error handling
 // 0.1.2    2020-09-22 fix typo
+// 0.1.3    2020-11-09 wait for read handling
 //
 // DHT PIN layout from left to right
 // =================================
-// FRONT : DESCRIPTION  
+// FRONT : DESCRIPTION
 // pin 1 : VCC
 // pin 2 : DATA
 // pin 3 : Not Connected
@@ -25,7 +26,7 @@ DHTNEW mySensor(16);   // ESP 16  UNO 6
 uint32_t count = 0;
 uint32_t start, stop;
 
-uint32_t errors[10] = { 0,0, 0,0, 0,0, 0,0, 0,0 };
+uint32_t errors[11] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 
 void setup()
@@ -44,8 +45,8 @@ void loop()
   if (count % 50 == 0)
   {
     Serial.println();
-    Serial.println("OK \tCRC \tTOA \tTOB \tTOC \tTOD \tSNR \tBS \tUNK");
-    for (uint8_t i = 0; i < 9; i++)
+    Serial.println("OK \tCRC \tTOA \tTOB \tTOC \tTOD \tSNR \tBS \tWFR \tUNK");
+    for (uint8_t i = 0; i < 10; i++)
     {
       Serial.print(errors[i]);
       Serial.print('\t');
@@ -102,11 +103,15 @@ void loop()
       Serial.print("BS,\t");
       errors[7]++;
       break;
+    case DHTLIB_WAITING_FOR_READ:
+      Serial.print("WFR,\t");
+      errors[8]++;
+      break;
     default:
       Serial.print("U");
       Serial.print(chk);
       Serial.print(",\t");
-      errors[8]++;
+      errors[9]++;
       break;
   }
   // DISPLAY DATA

--- a/examples/dhtnew_endless/dhtnew_endless.ino
+++ b/examples/dhtnew_endless/dhtnew_endless.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: DHT_endless.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.2
+// VERSION: 0.1.3
 // PURPOSE: demo
 //    DATE: 2020-06-04
 //    (c) : MIT

--- a/examples/dhtnew_setReadDelay/dhtnew_setReadDelay.ino
+++ b/examples/dhtnew_setReadDelay/dhtnew_setReadDelay.ino
@@ -8,6 +8,7 @@
 // HISTORY:
 // 0.1.0    2020-06-12 initial version
 // 0.1.1    2020-06-15 match 0.3.0 error handling
+// 0.1.2    2020-11-09 fix + wait for read handling
 //
 // DHT PIN layout from left to right
 // =================================
@@ -52,7 +53,10 @@ void setup()
     printStatus(chk);
 
     if (chk == DHTLIB_OK) rd -= step;
-    else rd += step;
+    else {
+      rd += step;
+      mySensor.read();
+    }
   }
 
   // safety margin of 100 uSec
@@ -106,6 +110,9 @@ void printStatus(int chk)
       break;
     case DHTLIB_ERROR_BIT_SHIFT:
       Serial.print("Bit shift error,\t");
+      break;
+    case DHTLIB_WAITING_FOR_READ:
+      Serial.print("Waiting for read,\t");
       break;
     default:
       Serial.print("Unknown: ");

--- a/examples/dhtnew_setReadDelay/dhtnew_setReadDelay.ino
+++ b/examples/dhtnew_setReadDelay/dhtnew_setReadDelay.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: dhtnew_setReadDelay.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.1
+// VERSION: 0.1.2
 // PURPOSE: DHTNEW library waitForRead example sketch for Arduino
 //     URL: https://github.com/RobTillaart/DHTNew
 //

--- a/examples/dhtnew_test/dhtnew_test.ino
+++ b/examples/dhtnew_test/dhtnew_test.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: dhtnew_test.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.5
+// VERSION: 0.1.6
 // PURPOSE: DHTNEW library test sketch for Arduino
 //     URL: https://github.com/RobTillaart/DHTNew
 //
@@ -12,10 +12,11 @@
 // 0.1.3    2020-04-30 replaced humidity and temperature with functions
 // 0.1.4    2020-06-08 improved error handling
 // 0.1.5    2020-06-15 match 0.3.0 error handling
+// 0.1.6    2020-11-09 wait for read handling
 //
 // DHT PIN layout from left to right
 // =================================
-// FRONT : DESCRIPTION  
+// FRONT : DESCRIPTION
 // pin 1 : VCC
 // pin 2 : DATA
 // pin 3 : Not Connected
@@ -117,6 +118,9 @@ void test()
       break;
     case DHTLIB_ERROR_BIT_SHIFT:
       Serial.print("Bit shift error,\t");
+      break;
+    case DHTLIB_WAITING_FOR_READ:
+      Serial.print("Waiting for read,\t");
       break;
     default:
       Serial.print("Unknown: ");

--- a/examples/dhtnew_waitForRead_nonBlocking/dhtnew_waitForRead_nonBlocking.ino
+++ b/examples/dhtnew_waitForRead_nonBlocking/dhtnew_waitForRead_nonBlocking.ino
@@ -1,0 +1,95 @@
+//
+//    FILE: dhtnew_waitForRead_nonBlocking.ino
+//  AUTHOR: Budulinek
+// VERSION: 0.1.0
+// PURPOSE: DHTNEW non-blocking wait for read example sketch for Arduino
+//     URL: https://github.com/RobTillaart/DHTNew
+//
+// HISTORY:
+// 0.1.0    2020-11-09 initial version
+//
+// DHT PIN layout from left to right
+// =================================
+// FRONT : DESCRIPTION
+// pin 1 : VCC
+// pin 2 : DATA
+// pin 3 : Not Connected
+// pin 4 : GND
+
+#include <dhtnew.h>
+
+DHTNEW mySensor(16);
+
+void setup()
+{
+  Serial.begin(115200);
+  Serial.println("\n");
+  Serial.println("dhtnew_waitForRead_nonBlocking.ino");
+  Serial.print("LIBRARY VERSION: ");
+  Serial.println(DHTNEW_LIB_VERSION);
+  Serial.println();
+  Serial.println("This example shows how you can use the output of the read() function to implement non-blocking waiting for read.");
+  Serial.println("In this example, Arduino continuously polls the read() function and returns fresh data (or an error) only when the read delay is over.");
+  Serial.println("Infinite loop.");
+  Serial.println();
+  Serial.println("STAT\tHUMI\tTEMP\tTIME\tTYPE");
+}
+
+void loop()
+{
+  // READ DATA
+  uint32_t start = micros();
+  int chk = mySensor.read();
+  uint32_t stop = micros();
+
+  if (chk != DHTLIB_WAITING_FOR_READ) {
+    switch (chk)
+    {
+      case DHTLIB_OK:
+        Serial.print("OK,\t");
+        break;
+      case DHTLIB_ERROR_CHECKSUM:
+        Serial.print("Checksum error,\t");
+        break;
+      case DHTLIB_ERROR_TIMEOUT_A:
+        Serial.print("Time out A error,\t");
+        break;
+      case DHTLIB_ERROR_TIMEOUT_B:
+        Serial.print("Time out B error,\t");
+        break;
+      case DHTLIB_ERROR_TIMEOUT_C:
+        Serial.print("Time out C error,\t");
+        break;
+      case DHTLIB_ERROR_TIMEOUT_D:
+        Serial.print("Time out D error,\t");
+        break;
+      case DHTLIB_ERROR_SENSOR_NOT_READY:
+        Serial.print("Sensor not ready,\t");
+        break;
+      case DHTLIB_ERROR_BIT_SHIFT:
+        Serial.print("Bit shift error,\t");
+        break;
+      default:
+        Serial.print("Unknown: ");
+        Serial.print(chk);
+        Serial.print(",\t");
+        break;
+    }
+
+    // DISPLAY DATA
+    Serial.print(mySensor.getHumidity(), 1);
+    Serial.print(",\t");
+    Serial.print(mySensor.getTemperature(), 1);
+    Serial.print(",\t");
+    uint32_t duration = stop - start;
+    Serial.print(duration);
+    Serial.print(",\t");
+    Serial.println(mySensor.getType());
+  }
+
+  // do some other stuff
+  delay(100);
+}
+
+
+// END OF FILE


### PR DESCRIPTION
At the moment, read() function returns DHTLIB_OK, without distinguishing between two situations:

1) Read successful
2) Waiting for read. Type is known from some previous readings (or from setType() function), but we actually do not know whether the sensor is connected or not.

Example:
```cpp
#include <dhtnew.h>

DHTNEW mySensor(16);

void setup()
{
  Serial.begin(115200);
  Serial.println("start");
  Serial.println();
  mySensor.setType(22);
} 

void loop()
{
  if (mySensor.read() == DHTLIB_OK) {
    Serial.print("OK:\t");
    Serial.println(mySensor.getTemperature(), 1);
  } else {
    Serial.println("ERROR");
  }
  delay(1000);      // < DHTLIB_DHT22_READ_DELAY
}
```
Gives me the following output with sensor not connected:

```
start

OK:	0.0
OK:	0.0
ERROR
ERROR
ERROR
OK:	-999.0
ERROR
ERROR
OK:	-999.0
ERROR
ERROR
ERROR
OK:	-999.0
ERROR
```
setWaitForReading(true) is not an option, I need non-blocking sketch.

I propose a simple solution: differentiate between DHTLIB_OK and DHTLIB_WAITING_FOR_READ

It will also allow us to implement non-blocking wait for read, for example:

```cpp
#include <dhtnew.h>

DHTNEW mySensor(16);

void setup()
{
  Serial.begin(115200);
  Serial.println("start");
  Serial.println();
  mySensor.setType(22);
}

void loop()
{
  int chk = mySensor.read();
  if (chk != DHTLIB_WAITING_FOR_READ) {
    if (chk == DHTLIB_OK) {
      Serial.print("OK:\t");
      Serial.println(mySensor.getTemperature(), 1);
    } else {
      Serial.println("ERROR");
    }
  }
  delay(100);      // << DHTLIB_DHT22_READ_DELAY
  // do other stuff while waiting for DHT22
}
```