### PR TITLE
calculateReadDelay()

### DIFF
--- a/dhtnew.cpp
+++ b/dhtnew.cpp
@@ -89,6 +89,8 @@ void DHTNEW::setType(uint8_t type)
 uint16_t DHTNEW::calculateReadDelay()
 {
   if (getType() == 0) return _readDelay;
+  _readDelay = DHTLIB_DHT22_READ_DELAY;
+  if (_type == 11) _readDelay = DHTLIB_DHT11_READ_DELAY;
   // finish previous reading (if there was some) and start new one
   while (millis() - _lastRead < _readDelay);
   _read();

--- a/dhtnew.h
+++ b/dhtnew.h
@@ -79,6 +79,7 @@ public:
   // set readDelay to 0 will reset to datasheet values
   uint16_t getReadDelay()                { return _readDelay; };
   void     setReadDelay(uint16_t rd = 0) { _readDelay = rd; };
+  uint16_t calculateReadDelay();
 
   // minimal support for low power applications.
   // after powerUp one must wait up to two seconds.


### PR DESCRIPTION
OK, I have one more thing in the pipeline. I really like the idea of calculating _readDelay based on real life reading interval (see the example dhtnew_setReadDelay.ino) . I have two DHT22, both of them have real life read interval 442 ms (instead of default 2000 ms).

So I propose this function to calculate _readDelay based on real life read interval. It is a "brute force" method, but very fast. The alternative would be:

```cpp
uint16_t DHTNEW::calculateReadDelay()
{
  if (getType() == 0) return _readDelay;
  _readDelay = DHTLIB_DHT22_READ_DELAY;
  if (_type == 11) _readDelay = DHTLIB_DHT11_READ_DELAY;
  // finish previous reading (if there was some) and start new one
  while (millis() - _lastRead < _readDelay);
  _read();
  
  uint16_t step = _readDelay;
  while (step)
  {
    step /= 2;
    Serial.println(_readDelay);
    delay(_readDelay);
    if (_read() == DHTLIB_OK) _readDelay -= step;
    else {
      delay(_readDelay);
      _read();
      _readDelay += step;
    }
  }
  // safety margin
  _readDelay += DHTLIB_READ_DELAY_MARGIN;
  return _readDelay;
}
```

The alternative is based on the example sketch, it is nice, elegant and accurate, but very slow (can take up between 8 and 30 seconds).