### PR TITLE
Problem: DHT22 sends minus 0 degree as sign-mag

### DIFF
--- a/dhtnew.cpp
+++ b/dhtnew.cpp
@@ -1,7 +1,7 @@
 //
 //    FILE: dhtnew.cpp
 //  AUTHOR: Rob.Tillaart@gmail.com
-// VERSION: 0.4.4
+// VERSION: 0.4.5
 // PURPOSE: DHT Temperature & Humidity Sensor library for Arduino
 //     URL: https://github.com/RobTillaart/DHTNEW
 //
@@ -37,6 +37,7 @@
 //  0.4.2  2020-12-15  fix negative temperatures
 //  0.4.3  2021-01-13  add reset(), add lastRead()
 //  0.4.4  2021-02-01  fix negative temperatures DHT22 (again)
+//  0.4.5  2021-02-14  fix -0°C encoding of DHT22
 
 
 #include "dhtnew.h"
@@ -189,7 +190,10 @@ int DHTNEW::_read()
   {
     _humidity    = (_bits[0] * 256 + _bits[1]) * 0.1;
     int16_t t    = (_bits[2] * 256 + _bits[3]);
-    _temperature = t * 0.1;
+    if(_bits[2] == 0x80)
+        _temperature = 0;
+    else
+        _temperature = t * 0.1; 
   }
   else // if (_type == 11)  // DHT11, DH12, compatible
   {

--- a/dhtnew.h
+++ b/dhtnew.h
@@ -2,7 +2,7 @@
 //
 //    FILE: dhtnew.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.4.4
+// VERSION: 0.4.5
 // PURPOSE: DHT Temperature & Humidity Sensor library for Arduino
 //     URL: https://github.com/RobTillaart/DHTNEW
 //
@@ -22,7 +22,7 @@
 #include "Arduino.h"
 
 
-#define DHTNEW_LIB_VERSION                (F("0.4.4"))
+#define DHTNEW_LIB_VERSION                (F("0.4.5"))
 
 
 #define DHTLIB_OK                         0


### PR DESCRIPTION
Problem is related to #52 

Solution:
Since all negative temperatures of DHT22 are send in two's complement, it is possible to detect sign-magnitude values and to catch if sensor outputs 0x8000 for a temperature lower then 0°C but higher then -0.1°C